### PR TITLE
fix: add additional restrictions when using batching

### DIFF
--- a/lib/inngest/function/config.ex
+++ b/lib/inngest/function/config.ex
@@ -101,6 +101,7 @@ defmodule Inngest.FnOpts do
   Validate the event batch settings
   """
   @spec validate_batch_events(t(), map()) :: map()
+  # credo:disable-for-next-line
   def validate_batch_events(fnopts, config) do
     case fnopts |> Map.get(:batch_events) do
       nil ->
@@ -113,6 +114,19 @@ defmodule Inngest.FnOpts do
         if is_nil(max_size) || is_nil(timeout) do
           raise Inngest.BatchEventConfigError,
             message: "'max_size' and 'timeout' must be set for batch_events"
+        end
+
+        rate_limit = Map.get(fnopts, :rate_limit)
+        cancel_on = Map.get(fnopts, :cancel_on)
+
+        if !is_nil(rate_limit) do
+          raise Inngest.BatchEventConfigError,
+            message: "'rate_limit' cannot be used with event_batches"
+        end
+
+        if !is_nil(cancel_on) do
+          raise Inngest.BatchEventConfigError,
+            lmessage: "'cancel_on' cannot be used with event_batches"
         end
 
         case Util.parse_duration(timeout) do

--- a/test/inngest/function/config_test.exs
+++ b/test/inngest/function/config_test.exs
@@ -115,6 +115,26 @@ defmodule Inngest.FnOptsTest do
                      FnOpts.validate_batch_events(opts, @config)
                    end
     end
+
+    test "should raise if rate limit is set with batching" do
+      opts = Map.put(@fn_opts, :rate_limit, %{limit: 1, period: "10m"})
+
+      assert_raise Inngest.BatchEventConfigError,
+                   "'rate_limit' cannot be used with event_batches",
+                   fn ->
+                     FnOpts.validate_batch_events(opts, @config)
+                   end
+    end
+
+    test "should raise if cancel_on is set with batching" do
+      opts = Map.put(@fn_opts, :cancel_on, %{event: "hello"})
+
+      assert_raise Inngest.BatchEventConfigError,
+                   "'cancel_on' cannot be used with event_batches",
+                   fn ->
+                     FnOpts.validate_batch_events(opts, @config)
+                   end
+    end
   end
 
   describe "validate_rate_limit/2" do


### PR DESCRIPTION
cancellation and rate limit can't be used with event batching, so make sure to add those validation as well.